### PR TITLE
Added dev install instructions & deprecation note about Related Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ the "Related" tab. This plugin simply surfaces those items above the "resources.
 description](http://i.imgur.com/M8dmuPc.png)
 
 ## Installation
-I'm new to CKAN plugins, so I'm not 100% sure how to install them yet, but I'm
-fairly certain you should be able to do something [like
-this](https://github.com/ckan/ckanext-disqus#activating-and-installing).
+
+```
+ . /usr/lib/ckan/default/bin/activate
+ cd /usr/lib/ckan/default/src
+ git clone https://github.com/CityOfPhiladelphia/ckanext-highlight-related-items
+ cd ckanext-highlight-related-items
+ python setup.py develop
+```
+
+## Note
+From CKAN v2.6, Related Items has been removed from CKAN, and replaced by the Showcase extension, which works with CKAN 2.3+.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ description](http://i.imgur.com/M8dmuPc.png)
 ```
 
 ## Note
-From CKAN v2.6, Related Items has been removed from CKAN, and replaced by the Showcase extension, which works with CKAN 2.3+.
+From CKAN v2.6, Related Items has been removed from CKAN, and replaced by the [Showcase extension](https://github.com/ckan/ckanext-showcase), which works with CKAN 2.3 and above.


### PR DESCRIPTION
Related items has been removed in CKAN 2.6 and largely supplanted by the Showcase extension