### PR TITLE
Fix README filename in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
`pip install` fails (because `setup.py build` fails) because it's trying
to load README.rst (the readme is README.md)